### PR TITLE
Explicitly specify the input file encoding as utf-8

### DIFF
--- a/ante.rb
+++ b/ante.rb
@@ -159,7 +159,7 @@ class Ante
 end
 
 if ARGV[0]
-  Ante.new.run(IO.read(ARGV[0]))
+  Ante.new.run(IO.read(ARGV[0], encoding: "utf-8"))
 else
   puts "usage: ante filename.ante"
 end


### PR DESCRIPTION
Hello,

`ante.rb` does not work when `LANG=C`.

```
$ LANG=C ruby -v ante.rb hello.ante
ruby 2.1.2p95 (2014-05-08 revision 45877) [x86_64-linux]
ante.rb:46:in `split': invalid byte sequence in US-ASCII (ArgumentError)
        from ante.rb:46:in `parse'
        from ante.rb:29:in `run'
        from ante.rb:162:in `<main>'
```

This can be fixed by specifying the input file encoding explicitly.

Thank you,
